### PR TITLE
Fix python_version format

### DIFF
--- a/cloudpassagehalo.json
+++ b/cloudpassagehalo.json
@@ -15,10 +15,7 @@
     "min_phantom_version": "5.1.0",
     "logo": "logo_cloudpassage.svg",
     "logo_dark": "logo_cloudpassage_dark.svg",
-    "python_version": [
-        "3.9",
-        "3.13"
-    ],
+    "python_version": "3.9, 3.13",
     "fips_compliant": true,
     "latest_tested_versions": [
         "On cloud, tested on August 12, 2021"

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Fix python_version 3.13 format


### PR DESCRIPTION
- Fix python_version format in app JSON files from array `["3.9", "3.13"]` to string `"3.9, 3.13"`

[_Created by Sourcegraph batch change `grokas-splunk/003-fix-python-version-format`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/003-fix-python-version-format)